### PR TITLE
Documentation typo in select field options

### DIFF
--- a/docs/fields/select.mdx
+++ b/docs/fields/select.mdx
@@ -15,7 +15,7 @@ keywords: select, multi-select, fields, config, configuration, documentation, Co
 | Option           | Description |
 | ---------------- | ----------- |
 | **`name`** *         | To be used as the property name when stored and retrieved from the database.  |
-| **`options`** *      | Array of options to allow the field to store. Can either be an array of strings, or an array of objects containing an `option` string and a `value` string. |
+| **`options`** *      | Array of options to allow the field to store. Can either be an array of strings, or an array of objects containing an `label` string and a `value` string. |
 | **`hasMany`**        | Boolean when, if set to `true`, allows this field to have many selections instead of only one. |
 | **`label`**          | Used as a field label in the Admin panel and to name the generated GraphQL type. |
 | **`unique`**         | Enforce that each entry in the Collection has a unique value for this field. |


### PR DESCRIPTION
## Description

Typo on the docs for Select fields. Instead of options being `{ label, value }` the top of the docs described it being `{ option, value }`.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] This change requires a documentation update

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
